### PR TITLE
Add basic layout

### DIFF
--- a/packages/next-app/src/components/ClaimBox.tsx
+++ b/packages/next-app/src/components/ClaimBox.tsx
@@ -1,0 +1,13 @@
+import { Box } from "@chakra-ui/react";
+
+export const ClaimBox = () => {
+  return (
+    <Box
+      w="320px"
+      h="320px"
+      backgroundColor="white"
+      borderRadius="24px"
+      mt="25vh"
+    />
+  );
+};

--- a/packages/next-app/src/components/MainBox.tsx
+++ b/packages/next-app/src/components/MainBox.tsx
@@ -1,0 +1,15 @@
+import { Box } from "@chakra-ui/react";
+
+export const MainBox = () => {
+  return (
+    <Box
+      w={["320px"]}
+      h="200px"
+      mh={["24px", "0"]}
+      backgroundColor="white"
+      borderRadius="24px"
+      position="absolute"
+      top="35vh"
+    />
+  );
+};

--- a/packages/next-app/src/pages/index.tsx
+++ b/packages/next-app/src/pages/index.tsx
@@ -2,11 +2,13 @@ import type { NextPage } from "next";
 import Head from "next/head";
 import { useCallback, useEffect, useState } from "react";
 import { ethers } from "ethers";
-import { Container, Box } from "@chakra-ui/react";
+import { Box, Flex } from "@chakra-ui/react";
 
 import { CODEToken__factory } from "@/typechain";
 import { hasEthereum } from "@/utils";
-import { Button } from "@/components/Button";
+
+import { ClaimBox } from "components/ClaimBox";
+import { MainBox } from "components/MainBox";
 
 const contractAddress = "0x5FbDB2315678afecb367f032d93F642f64180aa3";
 
@@ -33,12 +35,32 @@ const Home: NextPage = () => {
   }, []);
 
   return (
-    <Box>
+    <Box m="0" w="100vw" h="100vh" background="blue">
       <Head>
         <title>$CODE Claim Page</title>
       </Head>
-      <Button label="TODO" />
-      <Container>{claimPeriodEnds}</Container>
+      <Flex direction="row" flexWrap="wrap">
+        <Box
+          w={["100vw", "50vw"]}
+          h="100vh"
+          m="0"
+          pl="5vw"
+          background="#08010D"
+        >
+          <Box mt="48px">Developer DAO</Box>
+          <MainBox />
+        </Box>
+        <Box
+          w={["100vw", "50vw"]}
+          h="100vh"
+          m="0"
+          backgroundColor="#F1F0F5"
+          align="center"
+          justifyContent="center"
+        >
+          <ClaimBox />
+        </Box>
+      </Flex>
     </Box>
   );
 };


### PR DESCRIPTION
### What does it do?
Adds basic layout of the site (including breakpoint for mobile).

### Any helpful background information?
This is already further improved in the next PR that I'll create for the `ClaimCard` but trying to keep the PR's small for quick reviews.

### Relevant screenshots/gifs

<img width="1440" alt="basic-layout" src="https://user-images.githubusercontent.com/2104965/150443060-66025b04-33fe-4c83-9f64-af21bb272709.png">

### Does it close any issues?

Closes #7 
