### PR TITLE
Claim status UX

### DIFF
--- a/packages/next-app/src/components/MainBox.tsx
+++ b/packages/next-app/src/components/MainBox.tsx
@@ -1,5 +1,3 @@
-import { useState, useEffect } from "react";
-import Confetti from "react-confetti";
 import { Button, ButtonType } from "@/components/Button";
 import { Wallet } from "@/components/Wallet";
 import { Box, Flex, Heading, Text } from "@chakra-ui/react";
@@ -10,58 +8,33 @@ interface MainBoxProps {
 }
 
 export const MainBox = ({ isConnected, isUnsupported }: MainBoxProps) => {
-  const [windowSize, setWindowSize] = useState({
-    width: 0,
-    height: 0,
-  });
-
-  useEffect(() => {
-    function handleResize() {
-      setWindowSize({
-        width: window.innerWidth,
-        height: window.innerHeight,
-      });
-    }
-    window.addEventListener("resize", handleResize);
-    handleResize();
-    return () => window.removeEventListener("resize", handleResize);
-  }, []);
-
   return (
-    <div>
-      <Confetti
-        width={windowSize.width}
-        height={windowSize.height}
-        colors={["#DD95FF"]}
-        hidden
-      />
-      <Box my={["24px", "0"]} w="100%">
-        <Heading
-          as="h1"
-          color="white"
-          fontSize={["44px", "96px"]}
-          fontWeight="500"
-        >
-          Airdrop
-        </Heading>
-        <Text
-          mt="5"
-          mb="8"
-          color="white"
-          fontSize={["20px", "24px"]}
-          fontWeight="500"
-          fontFamily="Zen Kaku Gothic New"
-        >
-          $CODE is the new governance token for Developer DAO. Connect your
-          wallet to determine your airdrop eligibility.
-        </Text>
-        <Flex direction={["column", "row"]}>
-          <Box mb={["4", "0"]} mr={["0", "7"]} w={["100%", "inherit"]}>
-            <Wallet isConnected={isConnected} isUnsupported={isUnsupported} />
-          </Box>
-          <Button label="LEARN MORE" buttonType={ButtonType.Learn} />
-        </Flex>
-      </Box>
-    </div>
+    <Box my={["24px", "0"]} w="100%">
+      <Heading
+        as="h1"
+        color="white"
+        fontSize={["44px", "96px"]}
+        fontWeight="500"
+      >
+        Airdrop
+      </Heading>
+      <Text
+        mt="5"
+        mb="8"
+        color="white"
+        fontSize={["20px", "24px"]}
+        fontWeight="500"
+        fontFamily="Zen Kaku Gothic New"
+      >
+        $CODE is the new governance token for Developer DAO. Connect your wallet
+        to determine your airdrop eligibility.
+      </Text>
+      <Flex direction={["column", "row"]}>
+        <Box mb={["4", "0"]} mr={["0", "7"]} w={["100%", "inherit"]}>
+          <Wallet isConnected={isConnected} isUnsupported={isUnsupported} />
+        </Box>
+        <Button label="LEARN MORE" buttonType={ButtonType.Learn} />
+      </Flex>
+    </Box>
   );
 };

--- a/packages/next-app/src/pages/index.tsx
+++ b/packages/next-app/src/pages/index.tsx
@@ -2,10 +2,12 @@ import type { NextPage } from "next";
 import Head from "next/head";
 import { Box, Flex, SlideFade } from "@chakra-ui/react";
 import { useAccount, useNetwork } from "wagmi";
+import { useState, useEffect, useRef } from "react";
 
 import { ClaimCard } from "@/components/ClaimCard";
 import { Logo } from "@/components/Logo";
 import { MainBox } from "@/components/MainBox";
+import Confetti from "react-confetti";
 
 const Home: NextPage = () => {
   const [{ data: networkData, error, loading }, switchNetwork] = useNetwork();
@@ -17,44 +19,73 @@ const Home: NextPage = () => {
     typeof accountData !== "undefined" &&
     Object.entries(accountData).length > 0;
 
+  const [windowSize, setWindowSize] = useState({
+    width: 0,
+    height: 0,
+  });
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    }
+    window.addEventListener("resize", handleResize);
+    handleResize();
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  const confettiRef = useRef() as React.Ref<HTMLCanvasElement>;
+
   return (
-    <Box m="0" w="100vw" h="100vh" background="blue">
-      <Head>
-        <title>$CODE Claim Page</title>
-      </Head>
-      <Flex direction="row" flexWrap="wrap">
-        <Box
-          w={{ base: "100vw", lg: "50vw" }}
-          h="100vh"
-          m="0"
-          pl={["24px", "5vw"]}
-          pr={["40px", "8vw"]}
-          background="#08010D"
-        >
-          <Box mt={["32px", "48px"]} mb="22vh">
-            <Logo />
-          </Box>
-          <MainBox
-            isConnected={isConnected}
-            isUnsupported={!!networkData.chain?.unsupported}
-          />
-        </Box>
-        <Flex
-          w={{ base: "100vw", lg: "50vw" }}
-          h="100vh"
-          m="0"
-          backgroundColor="#F1F0F5"
-          align="center"
-          justifyContent="center"
-        >
-          <SlideFade in={isConnected} offsetY="20px">
-            <Box m={["24px", "10vw"]}>
-              <ClaimCard />
+    <div>
+      <Confetti
+        width={windowSize.width}
+        height={windowSize.height}
+        colors={["#DD95FF"]}
+        ref={confettiRef}
+        hidden
+      />
+      <Box m="0" w="100vw" h="100vh" background="blue">
+        <Head>
+          <title>$CODE Claim Page</title>
+        </Head>
+
+        <Flex direction="row" flexWrap="wrap">
+          <Box
+            w={{ base: "100vw", lg: "50vw" }}
+            h="100vh"
+            m="0"
+            pl={["24px", "5vw"]}
+            pr={["40px", "8vw"]}
+            background="#08010D"
+          >
+            <Box mt={["32px", "48px"]} mb="22vh">
+              <Logo />
             </Box>
-          </SlideFade>
+            <MainBox
+              isConnected={isConnected}
+              isUnsupported={!!networkData.chain?.unsupported}
+            />
+          </Box>
+          <Flex
+            w={{ base: "100vw", lg: "50vw" }}
+            h="100vh"
+            m="0"
+            backgroundColor="#F1F0F5"
+            align="center"
+            justifyContent="center"
+          >
+            <SlideFade in={isConnected} offsetY="20px">
+              <Box m={["24px", "10vw"]}>
+                <ClaimCard confettiRef={confettiRef} />
+              </Box>
+            </SlideFade>
+          </Flex>
         </Flex>
-      </Flex>
-    </Box>
+      </Box>
+    </div>
   );
 };
 


### PR DESCRIPTION
### What does it do?

Shows toasts according to claim tx status.
Shows confetti and confirm toast after 10 confirmations.

### Any helpful background information?

Does not use an event listener, but tx.wait(10)
Moved confetti to index.txs so ref is accessible

### Any new dependencies? Why were they added?

no

### Relevant screenshots/gifs

### Does it close any issues?

Closes #13 part 5.
