### PR TITLE
Claimed card UI

### DIFF
--- a/packages/next-app/public/assets/block-confirmations.svg
+++ b/packages/next-app/public/assets/block-confirmations.svg
@@ -1,0 +1,14 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="12" r="12" fill="url(#paint0_linear_0_1)" fill-opacity="0.1"/>
+<circle cx="12" cy="12" r="5" fill="url(#paint1_linear_0_1)"/>
+<defs>
+<linearGradient id="paint0_linear_0_1" x1="1.7077e-08" y1="12.1412" x2="24" y2="12.1412" gradientUnits="userSpaceOnUse">
+<stop stop-color="#AD00FF"/>
+<stop offset="1" stop-color="#4E00EC"/>
+</linearGradient>
+<linearGradient id="paint1_linear_0_1" x1="7" y1="12.0588" x2="17" y2="12.0588" gradientUnits="userSpaceOnUse">
+<stop stop-color="#AD00FF"/>
+<stop offset="1" stop-color="#4E00EC"/>
+</linearGradient>
+</defs>
+</svg>

--- a/packages/next-app/src/components/ClaimCard.tsx
+++ b/packages/next-app/src/components/ClaimCard.tsx
@@ -1,4 +1,12 @@
-import { Box, Button, Flex, Image, Spacer, Text } from "@chakra-ui/react";
+import {
+  Box,
+  Button,
+  Flex,
+  Image,
+  Spacer,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
 import { MouseEventHandler, useEffect, useState } from "react";
 import { useAccount, useSigner } from "wagmi";
 import MerkleTree from "merkletreejs";
@@ -246,6 +254,9 @@ export const ClaimCard = () => {
     fetchEns: true,
   });
 
+  const [claimDate, setClaimDate] = useState(new Date());
+  const [blockConfirmations, setBlockConfirmations] = useState(10);
+
   const allocations =
     accountData?.address &&
     ethers.utils.getAddress(accountData.address) in airdrop
@@ -334,18 +345,22 @@ export const ClaimCard = () => {
         />
       </Box>
       <Flex direction="column" mb="8">
-        <Box border="1px solid #08010D" opacity="8%" />
-        {positions.map((pos, index) => {
-          return (
-            <Box key={index} my="2">
-              <Position
-                title={pos.title}
-                value={pos.value.toString()}
-                isBig={false}
-              />
-            </Box>
-          );
-        })}
+        {cardState !== ClaimCardState.claimed && (
+          <Box border="1px solid #08010D" opacity="8%" />
+        )}
+        {cardState !== ClaimCardState.claimed &&
+          positions.map((pos, index) => {
+            return (
+              <Box key={index} my="2">
+                <Position
+                  title={pos.title}
+                  value={pos.value.toString()}
+                  isBig={false}
+                />
+              </Box>
+            );
+          })}
+
         <Box border="1px solid #08010D" opacity="8%" my="4" />
         <Box>
           <Position
@@ -353,6 +368,44 @@ export const ClaimCard = () => {
             value={totalAllocation.toString()}
             isBig={true}
           />
+          {cardState === ClaimCardState.claimed && (
+            <Box mt="16px">
+              <Text
+                px="24px"
+                fontFamily="Zen Kaku Gothic New"
+                color="#4E4853"
+                fontSize="18px"
+                fontWeight="500"
+              >
+                Claimed on{" "}
+                {claimDate.toLocaleDateString("en-UK", {
+                  day: "numeric",
+                  month: "long",
+                  year: "numeric",
+                })}
+              </Text>
+
+              <Flex mx="24px" mt="8px">
+                <Image
+                  src="assets/block-confirmations.svg"
+                  alt="confirmations"
+                  w="24px"
+                  h="24px"
+                  alignSelf="center"
+                />
+                <Text
+                  fontFamily="IBM Plex Mono"
+                  bgGradient="linear(to-r, #AD00FF, #4E00EC)"
+                  bgClip="text"
+                  fontSize="18px"
+                  fontWeight="500"
+                  pl="8px"
+                >
+                  {blockConfirmations} block confirmations
+                </Text>
+              </Flex>
+            </Box>
+          )}
         </Box>
       </Flex>
       <Box px="24px" pb="24px">

--- a/packages/next-app/src/components/ClaimCard.tsx
+++ b/packages/next-app/src/components/ClaimCard.tsx
@@ -412,7 +412,47 @@ export const ClaimCard = () => {
         {cardState === ClaimCardState.disconnected ? (
           <ButtonPlaceholder />
         ) : cardState === ClaimCardState.claimed ? (
-          <ButtonPlaceholder />
+          <Box>
+            <Button
+              background="#08010D"
+              borderRadius="12px"
+              color="#FFF"
+              fontSize={["16px", "18px"]}
+              fontWeight="900"
+              w="100%"
+              h="56px"
+              mb="8px"
+              _active={{}}
+              _hover={{
+                transform:
+                  "translate3d(0px, -2px, 0px) scale3d(1, 1, 1) rotateX(0deg) rotateY(0deg) rotateZ(0deg) skew(0deg, 0deg)",
+                transformStyle: "preserve-3d",
+              }}
+              //onClick={}
+            >
+              <Text>VIEW CLAIM TRANSACTION</Text>
+            </Button>
+
+            <Button
+              borderRadius="12px"
+              borderColor="#08010D"
+              borderWidth="2px"
+              color="#08010D"
+              fontSize={["16px", "18px"]}
+              fontWeight="900"
+              w="100%"
+              h="56px"
+              _active={{}}
+              _hover={{
+                transform:
+                  "translate3d(0px, -2px, 0px) scale3d(1, 1, 1) rotateX(0deg) rotateY(0deg) rotateZ(0deg) skew(0deg, 0deg)",
+                transformStyle: "preserve-3d",
+              }}
+              //onClick={}
+            >
+              <Text>ADD $CODE TO METAMASK</Text>
+            </Button>
+          </Box>
         ) : (
           <ClaimButton
             label={totalAllocation.toString()}


### PR DESCRIPTION
### What does it do?

Adds up to date Card UI for *claimed* state.

Date and block confirmations are hardcoded for now. They will be updated using a hook.
Buttons actions not implemented.

https://www.figma.com/file/TiqfRJnNxOQOSjA2TMkagD/%24CODE-Airdrop-Site-Designs?node-id=440%3A2755

### Relevant screenshots/gifs

<img width="1680" alt="Screenshot 2022-02-07 at 14 08 30" src="https://user-images.githubusercontent.com/8058187/152785499-a084ed9d-bb74-4f93-b921-0687e4dc1c10.png">
