### PR TITLE
Add $CODE token to MetaMask

### DIFF
--- a/packages/next-app/src/components/ClaimCard.tsx
+++ b/packages/next-app/src/components/ClaimCard.tsx
@@ -120,10 +120,26 @@ export enum ClaimCardState {
   notEligible,
 }
 
-const Avatar = () => {
-  return (
+const Avatar = ({
+  imageUrl,
+  showPlaceholder,
+}: {
+  imageUrl: string | null | undefined;
+  showPlaceholder: boolean;
+}) => {
+  const shouldShowPlaceholder =
+    showPlaceholder || imageUrl === null || imageUrl === undefined;
+  return shouldShowPlaceholder ? (
     <Box
       background="gray.200"
+      w={["96px", "120px"]}
+      h={["96px", "120px"]}
+      borderRadius="16px"
+    />
+  ) : (
+    <Image
+      src={imageUrl}
+      alt="avatar"
       w={["96px", "120px"]}
       h={["96px", "120px"]}
       borderRadius="16px"
@@ -177,7 +193,7 @@ interface HeaderData {
 
 const Header = ({ address, image, showLabel, showPlaceholder }: HeaderData) => (
   <Flex align="center">
-    <Avatar />
+    <Avatar imageUrl={image} showPlaceholder={showPlaceholder} />
     <Flex direction="column" ml={["20px", "32px"]}>
       {showLabel && (
         <Flex align="center">

--- a/packages/next-app/src/components/ClaimCard.tsx
+++ b/packages/next-app/src/components/ClaimCard.tsx
@@ -1,12 +1,4 @@
-import {
-  Box,
-  Button,
-  Flex,
-  Image,
-  Spacer,
-  Text,
-  VStack,
-} from "@chakra-ui/react";
+import { Box, Button, Flex, Image, Spacer, Text } from "@chakra-ui/react";
 import { MouseEventHandler, useEffect, useState } from "react";
 import { useAccount, useSigner } from "wagmi";
 import MerkleTree from "merkletreejs";

--- a/packages/next-app/src/components/ClaimCard.tsx
+++ b/packages/next-app/src/components/ClaimCard.tsx
@@ -9,6 +9,7 @@ import { CODEToken__factory } from "@/typechain";
 import { getContractAddress, maskWalletAddress } from "@/utils";
 
 import airdropData from "../data/airdrop";
+import { addCodeToken } from "../utils/add-token";
 
 const TOKEN_DECIMALS = 18;
 
@@ -292,6 +293,11 @@ export const ClaimCard = ({
     formattedAddress = maskWalletAddress(accountData.address);
   }
 
+  const addCodeToMetaMask = async () => {
+    if (window.ethereum === undefined) return;
+    await addCodeToken(window.ethereum);
+  };
+
   // Effect to set initial state after account connected
   useEffect(() => {
     const checkAlreadyClaimed = async () => {
@@ -462,7 +468,7 @@ export const ClaimCard = ({
                   "translate3d(0px, -2px, 0px) scale3d(1, 1, 1) rotateX(0deg) rotateY(0deg) rotateZ(0deg) skew(0deg, 0deg)",
                 transformStyle: "preserve-3d",
               }}
-              //onClick={}
+              onClick={addCodeToMetaMask}
             >
               <Text>ADD $CODE TO METAMASK</Text>
             </Button>

--- a/packages/next-app/src/utils/add-token.ts
+++ b/packages/next-app/src/utils/add-token.ts
@@ -1,0 +1,24 @@
+// FIXME: add real values (might be moved to a config file later)
+const tokenAddress = "";
+const tokenSymbol = "CODE";
+const tokenDecimals = 18;
+const tokenImage = "";
+
+export async function addCodeToken(ethereum: any) {
+  try {
+    await ethereum.request({
+      method: "wallet_watchAsset",
+      params: {
+        type: "ERC20",
+        options: {
+          address: tokenAddress,
+          symbol: tokenSymbol,
+          decimals: tokenDecimals,
+          image: tokenImage,
+        },
+      },
+    });
+  } catch (error) {
+    console.log(error);
+  }
+}


### PR DESCRIPTION
### What does it do?
Adds missing functionality for adding $CODE token to MetaMask - as described in the [docs](https://docs.metamask.io/guide/registering-your-token.html#example).

* Adds missing props for avatar component 
* Removes obsolete import

To test you can use the following lines in `utils/add-token.ts` to add $SOS token to MetaMask:
```
const tokenAddress = "0x3b484b82567a09e2588a13d54d032153f0c0aee0";
const tokenSymbol = "SOS";
const tokenDecimals = 18;
const tokenImage = "https://etherscan.io/token/images/sos.png";
```
### Does it close any issues?

Closes #43 
