### PR TITLE
setup default admin to the deployer

### DIFF
--- a/packages/hardhat/src/CODE.sol
+++ b/packages/hardhat/src/CODE.sol
@@ -9,7 +9,9 @@ contract CODE is ERC20, ERC20Permit, AccessControl {
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
     bytes32 public constant BURNER_ROLE = keccak256("BURNER_ROLE");
 
-    constructor() ERC20("Developer DAO", "CODE") ERC20Permit("Developer DAO") {}
+    constructor() ERC20("Developer DAO", "CODE") ERC20Permit("Developer DAO") {
+	_setupRole(DEFAULT_ADMIN_ROLE, _msgSender());
+    }
 
     function mint(address _to, uint256 _amount) external onlyRole(MINTER_ROLE) {
         _mint(_to, _amount);


### PR DESCRIPTION
### What does it do?
DEFAULT_ADMIN was not set at deployment to the deployer, can be included a parameter in the constructor. 
