### PR TITLE
Remove any minting capabilities from ClaimCODE

### DIFF
--- a/packages/hardhat/src/CODE.sol
+++ b/packages/hardhat/src/CODE.sol
@@ -4,10 +4,10 @@ pragma solidity ^0.8.9;
 import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/draft-ERC20Permit.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 
-contract CODE is ERC20, ERC20Permit, AccessControl {
+contract CODE is ERC20, ERC20Permit, AccessControl, ERC20Burnable {
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
-    bytes32 public constant BURNER_ROLE = keccak256("BURNER_ROLE");
 
     constructor() ERC20("Developer DAO", "CODE") ERC20Permit("Developer DAO") {
         _setupRole(DEFAULT_ADMIN_ROLE, _msgSender());
@@ -15,9 +15,5 @@ contract CODE is ERC20, ERC20Permit, AccessControl {
 
     function mint(address _to, uint256 _amount) external onlyRole(MINTER_ROLE) {
         _mint(_to, _amount);
-    }
-
-    function burn(address _to, uint256 _amount) external onlyRole(BURNER_ROLE) {
-        _burn(_to, _amount);
     }
 }

--- a/packages/hardhat/src/ClaimCODE.sol
+++ b/packages/hardhat/src/ClaimCODE.sol
@@ -5,13 +5,11 @@ import "./MerkleProof.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/security/Pausable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/structs/BitMaps.sol";
 
 import "hardhat/console.sol";
 
 contract ClaimCODE is Ownable, Pausable {
-    using SafeERC20 for IERC20;
     using BitMaps for BitMaps.BitMap;
 
     BitMaps.BitMap private claimed;
@@ -46,7 +44,7 @@ contract ClaimCODE is Ownable, Pausable {
         claimed.set(index);
         emit Claim(msg.sender, _amount);
 
-        codeToken.safeTransfer(msg.sender, _amount);
+        codeToken.transfer(msg.sender, _amount);
     }
 
     function isClaimed(uint256 index) public view returns (bool) {

--- a/packages/hardhat/src/ClaimCODE.sol
+++ b/packages/hardhat/src/ClaimCODE.sol
@@ -57,11 +57,11 @@ contract ClaimCODE is Ownable, Pausable {
         emit MerkleRootChanged(_merkleRoot);
     }
 
-    function pause() public onlyOwner {
+    function pause() external onlyOwner {
         _pause();
     }
 
-    function unpause() public onlyOwner {
+    function unpause() external onlyOwner {
         _unpause();
     }
 }

--- a/packages/hardhat/src/ClaimCODE.sol
+++ b/packages/hardhat/src/ClaimCODE.sol
@@ -6,9 +6,6 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/utils/structs/BitMaps.sol";
 
-interface IERC20Mintable is IERC20 {
-    function mint(address _to, uint256 _value) external;
-}
 import "hardhat/console.sol";
 
 contract ClaimCODE is Ownable {
@@ -18,39 +15,26 @@ contract ClaimCODE is Ownable {
     bytes32 public merkleRoot;
     uint256 public claimPeriodEnds;
 
-    bool public mintingEnabled = true;
-    bool public mintGovernance = true;
-
-    IERC20Mintable public immutable codeToken;
+    IERC20 public immutable codeToken;
 
     event MerkleRootChanged(bytes32 _merkleRoot);
     event Claim(address indexed _claimant, uint256 _amount);
-    event MintedByGovernance(address indexed _target, uint256 _amount);
-    event MintingDisabled();
 
     error Address0Error();
     error InvalidProof();
     error AlreadyClaimed();
     error ClaimEnded();
-    error ClaimNotEnabled();
-    error MintGovernanceDisable();
     error InitError();
 
-    constructor(
-        uint256 _claimPeriodEnds,
-        address _codeToken,
-        uint256 _airdropSupply
-    ) {
+    constructor(uint256 _claimPeriodEnds, address _codeToken) {
         if (_codeToken == address(0)) revert Address0Error();
         claimPeriodEnds = _claimPeriodEnds;
-        codeToken = IERC20Mintable(_codeToken);
-        codeToken.mint(address(this), _airdropSupply * 1e18);
+        codeToken = IERC20(_codeToken);
     }
 
     function claimTokens(uint256 _amount, bytes32[] calldata _merkleProof) external {
         bytes32 leaf = keccak256(abi.encodePacked(msg.sender, _amount));
         (bool valid, uint256 index) = MerkleProof.verify(_merkleProof, merkleRoot, leaf);
-        if (!mintingEnabled) revert ClaimNotEnabled();
         if (!valid) revert InvalidProof();
         if (isClaimed(index)) revert AlreadyClaimed();
         if (block.timestamp > claimPeriodEnds) revert ClaimEnded();
@@ -65,27 +49,9 @@ contract ClaimCODE is Ownable {
         return claimed.get(index);
     }
 
-    function mintByGovernance(address _target, uint256 _amount) external onlyOwner {
-        if (!mintGovernance) revert MintGovernanceDisable();
-        if (_target == address(0)) revert Address0Error();
-
-        emit MintedByGovernance(_target, _amount);
-        codeToken.mint(_target, _amount);
-    }
-
     function setMerkleRoot(bytes32 _merkleRoot) external onlyOwner {
         if (merkleRoot != bytes32(0)) revert InitError();
         merkleRoot = _merkleRoot;
         emit MerkleRootChanged(_merkleRoot);
-    }
-
-    function disableMinting() external onlyOwner {
-        mintingEnabled = false;
-        emit MintingDisabled();
-    }
-
-    function disableMintingByGovernance() external onlyOwner {
-        mintGovernance = false;
-        emit MintingDisabled();
     }
 }

--- a/packages/hardhat/src/deprecated/CODEToken.sol
+++ b/packages/hardhat/src/deprecated/CODEToken.sol
@@ -1,7 +1,7 @@
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.9;
 
-import "./MerkleProof.sol";
+import "../MerkleProof.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/draft-ERC20Permit.sol";

--- a/packages/hardhat/test/deprecated/CODEToken.test.ts
+++ b/packages/hardhat/test/deprecated/CODEToken.test.ts
@@ -1,10 +1,10 @@
-import { expect } from './chai-setup';
+import { expect } from '../chai-setup';
 import { ethers, deployments, getUnnamedAccounts, getNamedAccounts } from 'hardhat';
-import { CODEToken } from '../../next-app/src/typechain';
-import { setupUsers } from './utils';
-import { generateLeaf } from './utils/merkleUtils';
+import { CODEToken } from '../../../next-app/src/typechain';
+import { setupUsers } from '../utils';
+import { generateLeaf } from '../utils/merkleUtils';
 
-import MerkleGenerator from '../utils/merkleGenerator';
+import MerkleGenerator from '../../utils/merkleGenerator';
 
 const TOKEN_DECIMALS = 18;
 
@@ -85,7 +85,9 @@ describe('CODEToken', function () {
     const isClaimedAfter = await CODEToken.isClaimed(0);
     expect(isClaimedAfter).to.be.true;
 
-    await expect(users[1].CODEToken.claimTokens(correctNumTokens, correctProof)).to.be.revertedWith('CODE: Tokens already claimed.');
+    await expect(users[1].CODEToken.claimTokens(correctNumTokens, correctProof)).to.be.revertedWith(
+      'CODE: Tokens already claimed.'
+    );
 
     // Get tokens for address incorrectly using user[2]
     /* const otherFormattedAddress: string = ethers.utils.getAddress(users[2].address);


### PR DESCRIPTION
Remove any minting functionality from the ClaimCODE.sol contract, based on the discussion we had around our [Contract Finalization](https://developerdao.notion.site/CODE-Contract-Finalization-91da29cab9f14500ba55e77d3625f7da) meetings.
