### PR TITLE
Add a splash page if not claim site is not live yet

### DIFF
--- a/packages/next-app/src/pages/index.tsx
+++ b/packages/next-app/src/pages/index.tsx
@@ -3,6 +3,7 @@ import Head from "next/head";
 import {
   Box,
   Flex,
+  Heading,
   SlideFade,
   Spacer,
   Image,
@@ -22,7 +23,28 @@ import { SocialLinks } from "@/components/SocialLinks";
 import { SocialLinksMobile } from "@/components/SocialLinksMobile";
 import { bounceAnimation } from "@/chakra.config";
 
+// use live boolean to determine if we should show the claim page or coming soon page
+const live = false;
+
 const Home: NextPage = () => {
+  if (!live) {
+    // if not live, show a simple 'coming soon' page
+    return (
+          <Flex
+            m="0"
+            w="100vw"
+            h="100vh"
+            background="black"
+            align="center"
+            justifyContent="center"
+            textAlign={"center"}
+            >
+              <Heading as="h1" color="white" fontSize={"96px"} fontWeight="500">
+                Coming soon
+              </Heading>
+          </Flex>
+    );
+  } else {
   const [{ data: networkData, error, loading }] = useNetwork();
   const [{ data: accountData }, disconnect] = useAccount({
     fetchEns: true,
@@ -178,6 +200,7 @@ const Home: NextPage = () => {
       </Box>
     </div>
   );
+  }
 };
 
 export default Home;


### PR DESCRIPTION
### What does it do?
This adds a splash page if the claim site is not set to live.

### Any helpful background information?
This allows us to deploy the site to the subdomain without making the entire site visible which could open up vectors of attacks through copycat sites.
